### PR TITLE
Remove Finalizado and Cancelado cards from coordinator summary

### DIFF
--- a/src/components/CoordinatorView.tsx
+++ b/src/components/CoordinatorView.tsx
@@ -227,12 +227,6 @@ const CoordinatorView: React.FC<CoordinatorViewProps> = ({
         case 'PROGRAMADO':
           stats.programado++;
           break;
-        case 'FINALIZADO':
-          stats.finalizado++;
-          break;
-        case 'CANCELADO':
-          stats.cancelado++;
-          break;
         case 'CANCELACION_SOLICITADA':
           stats.cancelacionSolicitada++;
           break;
@@ -244,8 +238,6 @@ const CoordinatorView: React.FC<CoordinatorViewProps> = ({
     }, {
       pendiente: 0,
       programado: 0,
-      cancelado: 0,
-      finalizado: 0,
       cancelacionSolicitada: 0,
       noShow: 0
     });

--- a/src/components/ServiceDashboard.tsx
+++ b/src/components/ServiceDashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Clock, CheckCircle, XCircle, AlertTriangle, UserX, Truck, ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
+import { Clock, CheckCircle, AlertTriangle, UserX, ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
 import DatePicker from 'react-datepicker';
 import { registerLocale } from 'react-datepicker';
 import es from 'date-fns/locale/es';
@@ -11,8 +11,6 @@ registerLocale('es', es);
 interface ServiceStats {
   pendiente: number;
   programado: number;
-  cancelado: number;
-  finalizado: number;
   cancelacionSolicitada: number;
   noShow: number;
 }
@@ -56,26 +54,6 @@ const ServiceDashboard: React.FC<ServiceDashboardProps> = ({
       iconColor: 'text-green-600',
       textColor: 'text-green-900',
       status: 'PROGRAMADO'
-    },
-    {
-      label: 'Finalizados',
-      current: currentStats.finalizado,
-      icon: Truck,
-      bgColor: 'bg-blue-50',
-      borderColor: 'border-blue-200',
-      iconColor: 'text-blue-600',
-      textColor: 'text-blue-900',
-      status: 'FINALIZADO'
-    },
-    {
-      label: 'Cancelados',
-      current: currentStats.cancelado,
-      icon: XCircle,
-      bgColor: 'bg-red-50',
-      borderColor: 'border-red-200',
-      iconColor: 'text-red-600',
-      textColor: 'text-red-900',
-      status: 'CANCELADO'
     },
     {
       label: 'Cancelación Solicitada',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,8 +88,6 @@ export interface Driver {
 export interface ServiceStats {
   pendiente: number;
   programado: number;
-  cancelado: number;
-  finalizado: number;
   cancelacionSolicitada: number;
   noShow: number;
 }


### PR DESCRIPTION
## Summary
- drop Finalizados and Cancelados cards from service dashboard
- update service stats types accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a774008c98832386bfb8d86d1cf1cf