### PR TITLE
Ajusta proporción de baldosas

### DIFF
--- a/src/components/ServiceDashboard.tsx
+++ b/src/components/ServiceDashboard.tsx
@@ -195,7 +195,7 @@ const ServiceDashboard: React.FC<ServiceDashboardProps> = ({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {statCards.map((stat) => (
           <button
             key={stat.label}


### PR DESCRIPTION
## Summary
- Corrige la grilla del tablero de servicios para mostrar cuatro baldosas sin espacios vacíos.

## Testing
- `npm test` (falla: Missing script "test")
- `npm run lint` (falla: Invalid option '--ext')
- `npx eslint .` (falla: Cannot find package 'typescript-eslint')


------
https://chatgpt.com/codex/tasks/task_e_68a777719b1c8323a664cb14ecee6ed0