### PR TITLE
Remove scheduled services filter from coordination panel

### DIFF
--- a/src/components/CoordinatorView.tsx
+++ b/src/components/CoordinatorView.tsx
@@ -114,7 +114,6 @@ const CoordinatorView: React.FC<CoordinatorViewProps> = ({
   // Status options for filter
   const statusOptions = [
     { value: 'PENDIENTE', label: 'Pendiente', color: 'yellow' },
-    { value: 'PROGRAMADO', label: 'Programado', color: 'green' },
     { value: 'FINALIZADO', label: 'Finalizado', color: 'blue' },
     { value: 'CANCELADO', label: 'Cancelado', color: 'red' },
     { value: 'CANCELACION_SOLICITADA', label: 'Cancelación Solicitada', color: 'orange' },


### PR DESCRIPTION
## Summary
- remove Programado from status options to hide scheduled services filter in coordinator panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext', missing dependency `typescript-eslint`)


------
https://chatgpt.com/codex/tasks/task_e_68a77b5b98948323856fe25f1acf85f5