### PR TITLE
Add coordinator navigation menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import LoginView from './components/LoginView';
 import ListaServiciosView from './components/ListaServiciosView';
 import SolicitudTransporteView from './components/SolicitudTransporteView';
 import BulkServiceRequestView from './components/BulkServiceRequestView';
-import CoordinatorView from './components/CoordinatorView';
+import CoordinatorPanel from './components/CoordinatorPanel';
 import ChangelogModal from './components/ChangelogModal';
 import { Authorization, Service, ServiceFormData } from './types';
 import { 
@@ -305,9 +305,9 @@ function App() {
         />
       )}
       
-      {/* Coordinator View */}
+      {/* Coordinator View wrapped with side navigation */}
       {currentView === 'coordinator' && (
-        <CoordinatorView
+        <CoordinatorPanel
           services={sharedServices}
           onGoBack={handleGoHome}
           onUpdateService={handleUpdateService}

--- a/src/components/CoordinatorPanel.tsx
+++ b/src/components/CoordinatorPanel.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { ChevronDown, ClipboardList, Users, FileText } from 'lucide-react';
+import CoordinatorView from './CoordinatorView';
+import { Service } from '../types';
+
+interface CoordinatorPanelProps {
+  services: Service[];
+  onGoBack: () => void;
+  onUpdateService: (updatedService: Service) => void;
+  onCancellationAction: (serviceId: string, action: 'approve' | 'reject') => void;
+}
+
+const CoordinatorPanel: React.FC<CoordinatorPanelProps> = ({
+  services,
+  onGoBack,
+  onUpdateService,
+  onCancellationAction,
+}) => {
+  return (
+    <div className="flex min-h-screen">
+      <nav className="w-64 bg-[#020432] text-white flex flex-col">
+        <div className="p-4 text-xl font-bold border-b border-white/20">
+          Panel interactivo
+        </div>
+        <div className="px-4 py-2 flex items-center justify-between text-sm font-semibold border-b border-white/20">
+          <span>Gestión de servicios</span>
+          <ChevronDown className="h-4 w-4" />
+        </div>
+        <ul className="flex-1 py-2 space-y-1 text-sm">
+          {['Seguimiento de servicios', 'Servicios en ejecución', 'Servicios programados'].map((text) => (
+            <li
+              key={text}
+              className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed"
+            >
+              <ClipboardList className="h-4 w-4" />
+              <span>{text}</span>
+            </li>
+          ))}
+          <li className="px-4 py-2 flex items-center space-x-2 bg-blue-600">
+            <ClipboardList className="h-4 w-4" />
+            <span>Servicios solicitados por el cliente</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <ClipboardList className="h-4 w-4" />
+            <span>Servicios cancelados</span>
+          </li>
+        </ul>
+        <ul className="py-2 space-y-1 text-sm">
+          {['Solicitar servicio', 'Generar Link de Servicio', 'Cargue de servicios', 'Paradas programadas'].map((text) => (
+            <li
+              key={text}
+              className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed"
+            >
+              <FileText className="h-4 w-4" />
+              <span>{text}</span>
+            </li>
+          ))}
+          <li className="px-4 py-2 flex items-center space-x-2 hover:bg-gray-700">
+            <Users className="h-4 w-4" />
+            <a
+              href="https://capable-buttercream-d72771.netlify.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Gestion de usuarios
+            </a>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <FileText className="h-4 w-4" />
+            <span>Reportes</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <FileText className="h-4 w-4" />
+            <span>Geolocalizador</span>
+          </li>
+        </ul>
+      </nav>
+      <div className="flex-1">
+        <CoordinatorView
+          services={services}
+          onGoBack={onGoBack}
+          onUpdateService={onUpdateService}
+          onCancellationAction={onCancellationAction}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CoordinatorPanel;


### PR DESCRIPTION
## Summary
- add constant side navigation in coordinator panel with requested options
- highlight "Servicios solicitados por el cliente" and link "Gestion de usuarios" to external app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7802c5b508323a42b1f421d986c31