### PR TITLE
feat: add requested services menu and refresh sidebar

### DIFF
--- a/src/components/CoordinatorPanel.tsx
+++ b/src/components/CoordinatorPanel.tsx
@@ -1,5 +1,19 @@
 import React from 'react';
-import { ChevronDown, ClipboardList, Users, FileText } from 'lucide-react';
+import {
+  BarChart2,
+  Calendar,
+  ChevronDown,
+  ClipboardList,
+  Clock,
+  ExternalLink,
+  FilePlus,
+  Link as LinkIcon,
+  MapPin,
+  PlayCircle,
+  Upload,
+  Users,
+  XCircle,
+} from 'lucide-react';
 import CoordinatorView from './CoordinatorView';
 import { Service } from '../types';
 
@@ -18,7 +32,7 @@ const CoordinatorPanel: React.FC<CoordinatorPanelProps> = ({
 }) => {
   return (
     <div className="flex min-h-screen">
-      <nav className="w-64 bg-[#020432] text-white flex flex-col">
+      <nav className="w-64 bg-[#1e2236] text-white flex flex-col">
         <div className="p-4 text-xl font-bold border-b border-white/20">
           Panel interactivo
         </div>
@@ -27,35 +41,52 @@ const CoordinatorPanel: React.FC<CoordinatorPanelProps> = ({
           <ChevronDown className="h-4 w-4" />
         </div>
         <ul className="flex-1 py-2 space-y-1 text-sm">
-          {['Seguimiento de servicios', 'Servicios en ejecución', 'Servicios programados'].map((text) => (
-            <li
-              key={text}
-              className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed"
-            >
-              <ClipboardList className="h-4 w-4" />
-              <span>{text}</span>
-            </li>
-          ))}
-          <li className="px-4 py-2 flex items-center space-x-2 bg-blue-600">
-            <ClipboardList className="h-4 w-4" />
-            <span>Servicios solicitados por el cliente</span>
-          </li>
           <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
             <ClipboardList className="h-4 w-4" />
+            <span>Seguimiento de servicios</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <PlayCircle className="h-4 w-4" />
+            <span>Servicios en ejecución</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <Calendar className="h-4 w-4" />
+            <span>Servicios programados</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 hover:bg-white/10 border-l-4 border-green-500">
+            <ExternalLink className="h-4 w-4 text-green-400" />
+            <a
+              href="https://capable-buttercream-d72771.netlify.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-400"
+            >
+              Servicios solicitados por el cliente
+            </a>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <XCircle className="h-4 w-4" />
             <span>Servicios cancelados</span>
           </li>
         </ul>
         <ul className="py-2 space-y-1 text-sm">
-          {['Solicitar servicio', 'Generar Link de Servicio', 'Cargue de servicios', 'Paradas programadas'].map((text) => (
-            <li
-              key={text}
-              className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed"
-            >
-              <FileText className="h-4 w-4" />
-              <span>{text}</span>
-            </li>
-          ))}
-          <li className="px-4 py-2 flex items-center space-x-2 hover:bg-gray-700">
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <FilePlus className="h-4 w-4" />
+            <span>Solicitar servicio</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <LinkIcon className="h-4 w-4" />
+            <span>Generar Link de Servicio</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <Upload className="h-4 w-4" />
+            <span>Cargue de servicios</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
+            <Clock className="h-4 w-4" />
+            <span>Paradas programadas</span>
+          </li>
+          <li className="px-4 py-2 flex items-center space-x-2 hover:bg-white/10">
             <Users className="h-4 w-4" />
             <a
               href="https://capable-buttercream-d72771.netlify.app/"
@@ -66,11 +97,11 @@ const CoordinatorPanel: React.FC<CoordinatorPanelProps> = ({
             </a>
           </li>
           <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
-            <FileText className="h-4 w-4" />
+            <BarChart2 className="h-4 w-4" />
             <span>Reportes</span>
           </li>
           <li className="px-4 py-2 flex items-center space-x-2 opacity-50 cursor-not-allowed">
-            <FileText className="h-4 w-4" />
+            <MapPin className="h-4 w-4" />
             <span>Geolocalizador</span>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- add "Servicios solicitados por el cliente" menu linking to external portal
- restyle sidebar with darker background and icon-based entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68a781fe7adc83239cdcb052c4049b01