### PR TITLE
Unify Tarifa asignada labels

### DIFF
--- a/src/components/AuthorizationTable.tsx
+++ b/src/components/AuthorizationTable.tsx
@@ -38,7 +38,7 @@ const AuthorizationTable: React.FC<AuthorizationTableProps> = ({ authorizations,
       <table className="min-w-[1100px] md:min-w-full divide-y divide-gray-200 table-auto">
         <thead className="bg-gray-50">
           <tr>
-            <th className="px-4 py-2 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">Tarifa / Código Único</th>
+            <th className="px-4 py-2 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">Tarifa asignada / Código Único</th>
             <th className="px-4 py-2 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">Número de Volante</th>
             <th className="px-4 py-2 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">Vigencia</th>
             <th className="px-4 py-2 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">Servicios</th>

--- a/src/components/BulkServiceRequestView.tsx
+++ b/src/components/BulkServiceRequestView.tsx
@@ -281,7 +281,7 @@ const BulkServiceRequestView: React.FC<BulkServiceRequestViewProps> = ({
 
             <div>
               <label className="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">
-                Tarifa UT:
+                Tarifa asignada:
               </label>
               <p className="text-sm text-gray-900 font-medium">
                 {authorization.tarifaUT || '-'}

--- a/src/components/CancelServiceModal.tsx
+++ b/src/components/CancelServiceModal.tsx
@@ -116,7 +116,7 @@ const CancelServiceModal: React.FC<CancelServiceModalProps> = ({
                               <p className="text-gray-900">{service.volante}</p>
                             </div>
                             <div>
-                              <p className="text-gray-600 font-medium">Tarifa:</p>
+                              <p className="text-gray-600 font-medium">Tarifa asignada:</p>
                               <p className="text-gray-900">{service.tarifaUT}</p>
                             </div>
                           </div>

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -236,7 +236,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
                             </div>
                           </div>
                           <div>
-                            <span className="text-blue-700">Tarifa:</span>
+                            <span className="text-blue-700">Tarifa asignada:</span>
                             <p className="font-medium text-blue-900">{authorization.tarifaUT}</p>
                           </div>
                           <div>

--- a/src/components/SolicitudTransporteView.tsx
+++ b/src/components/SolicitudTransporteView.tsx
@@ -498,7 +498,7 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
 
             <div>
               <label className="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">
-                Tarifa UT:
+                Tarifa asignada:
               </label>
               <p className="text-sm text-gray-900 font-medium">
                 {authorization.tarifaUT || '-'}


### PR DESCRIPTION
## Summary
- update headings and field labels so the assigned rate is always shown as "Tarifa asignada"
- apply the new wording across confirmation, cancelation, and request views for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c858bd21a88323a10bb4b9cfe846ef