### PR TITLE
Unificar solicitud individual y masiva en la vista de transporte

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import CorporateHomeView from './components/CorporateHomeView';
 import HomeSelector from './components/HomeSelector';
 import ListaServiciosView from './components/ListaServiciosView';
 import SolicitudTransporteView from './components/SolicitudTransporteView';
-import BulkServiceRequestView from './components/BulkServiceRequestView';
 import CoordinatorPanel from './components/CoordinatorPanel';
 import { Authorization, Service, ServiceFormData } from './types';
 import { 
@@ -16,13 +15,15 @@ import {
   mockPastServices 
 } from './data/mockData';
 
-type AppView = 'home' | 'user-list' | 'user-form' | 'user-bulk-form' | 'coordinator';
+type AppView = 'home' | 'user-list' | 'user-form' | 'coordinator';
+type RequestMode = 'single' | 'bulk';
 type HomeType = 'original' | 'alternative' | 'corporate';
 
 function App() {
   const [currentView, setCurrentView] = useState<AppView>('home');
   const [currentHome, setCurrentHome] = useState<HomeType>('corporate');
   const [selectedAuthorization, setSelectedAuthorization] = useState<Authorization | null>(null);
+  const [requestMode, setRequestMode] = useState<RequestMode>('single');
   // Shared services state between user and coordinator
   const [sharedServices, setSharedServices] = useState<Service[]>(mockPastServices);
   const [newlyAddedServiceId, setNewlyAddedServiceId] = useState<string | null>(null);
@@ -41,14 +42,10 @@ function App() {
     setSelectedAuthorization(null);
   };
 
-  const handleShowForm = (authorization: Authorization) => {
+  const handleShowForm = (authorization: Authorization, mode: RequestMode = 'single') => {
     setSelectedAuthorization(authorization);
+    setRequestMode(mode);
     setCurrentView('user-form');
-  };
-
-  const handleShowBulkForm = (authorization: Authorization) => {
-    setSelectedAuthorization(authorization);
-    setCurrentView('user-bulk-form');
   };
 
   const handleGoBackToList = () => {
@@ -190,7 +187,6 @@ function App() {
           pastServices={sharedServices}
           newlyAddedServiceId={newlyAddedServiceId}
           onShowForm={handleShowForm}
-          onShowBulkForm={handleShowBulkForm}
           onUpdateService={handleUpdateService}
           onCancelService={handleCancelService}
           onUpdateUserInfo={handleUpdateUserInfo}
@@ -207,18 +203,7 @@ function App() {
           onScheduleServices={handleScheduleServices}
           onUpdateUserInfo={handleUpdateUserInfo}
           onLogout={handleLogout}
-        />
-      )}
-
-      {currentView === 'user-bulk-form' && selectedAuthorization && (
-        <BulkServiceRequestView
-          userInfo={userInfo}
-          patientInfo={mockPatientInfo}
-          authorization={selectedAuthorization}
-          onGoBack={handleGoBackToList}
-          onScheduleServices={handleScheduleServices}
-          onUpdateUserInfo={handleUpdateUserInfo}
-          onLogout={handleLogout}
+          initialMode={requestMode}
         />
       )}
       

--- a/src/components/CancelRequestModal.tsx
+++ b/src/components/CancelRequestModal.tsx
@@ -1,0 +1,86 @@
+import React, { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface CancelRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const CancelRequestModal: React.FC<CancelRequestModalProps> = ({ isOpen, onClose, onConfirm }) => {
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <AlertTriangle className="h-6 w-6 text-yellow-500" />
+                    <Dialog.Title as="h3" className="text-lg font-semibold text-gray-900">
+                      Cancelar solicitud
+                    </Dialog.Title>
+                  </div>
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-500"
+                    onClick={onClose}
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <div className="mt-4">
+                  <p className="text-sm text-gray-600">
+                    Los datos diligenciados se borrarán. ¿Está seguro que quiere volver a la página principal?
+                  </p>
+                </div>
+
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="inline-flex justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300"
+                  >
+                    No, permanecer aquí
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onConfirm}
+                    className="inline-flex justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                  >
+                    Sí, salir
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default CancelRequestModal;

--- a/src/components/ListaServiciosView.tsx
+++ b/src/components/ListaServiciosView.tsx
@@ -14,8 +14,7 @@ interface ListaServiciosViewProps {
   authorizations: Authorization[];
   pastServices: Service[];
   newlyAddedServiceId: string | null;
-  onShowForm: (authorization: Authorization) => void;
-  onShowBulkForm: (authorization: Authorization) => void;
+  onShowForm: (authorization: Authorization, mode?: 'single' | 'bulk') => void;
   onUpdateService: (updatedService: Service) => void;
   onCancelService: (serviceId: string) => void;
   onUpdateUserInfo: (updatedInfo: { email: string; phoneNumber: string; address: string }) => void;
@@ -29,7 +28,6 @@ const ListaServiciosView: React.FC<ListaServiciosViewProps> = ({
   pastServices,
   newlyAddedServiceId,
   onShowForm: _onShowForm,
-  onShowBulkForm: _onShowBulkForm,
   onUpdateService,
   onCancelService,
   onUpdateUserInfo,
@@ -178,11 +176,11 @@ const ListaServiciosView: React.FC<ListaServiciosViewProps> = ({
 
   // Acciones para abrir los formularios desde la tabla
   const handleRequestSingle = (auth: GroupedAuthorization) => {
-    _onShowForm(auth);
+    _onShowForm(auth, 'single');
   };
 
   const handleRequestBulk = (auth: GroupedAuthorization) => {
-    _onShowBulkForm(auth);
+    _onShowForm(auth, 'bulk');
   };
 
   const clearFilters = () => {


### PR DESCRIPTION
## Summary
- unifica la solicitud individual y masiva en `SolicitudTransporteView`, agregando estado de modo, tabla editable para servicios múltiples y sincronización con la lógica existente
- agrega el modal `CancelRequestModal` para confirmar la cancelación dentro de la pantalla de solicitud
- actualiza `App` y `ListaServiciosView` para abrir la vista única en modo individual o masivo según la acción del usuario

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8613a0b308323bd65ce65fd8b082a