### PR TITLE
Enhance return service generation controls

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,7 @@ export interface ServiceFormData {
   telefonoAdicional?: string;
   tipo?: 'IDA' | 'REGRESO' | 'ADICIONAL';
   observaciones?: string;
+  relatedServiceId?: string;
 }
 
 export interface Driver {


### PR DESCRIPTION
## Summary
- remove the previous “Añadir más servicios” action and add a new control to create inverted return services for each individual request
- link return entries to their base service with `relatedServiceId` so the data stays synchronized when editing or deleting
- update the return toggle and validations to respect authorization limits and show clearer warnings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9755bbbcc83238f5a5174a8604638