### PR TITLE
Add UUID helper with fallbacks

### DIFF
--- a/src/components/BulkServiceRequestView.tsx
+++ b/src/components/BulkServiceRequestView.tsx
@@ -9,6 +9,7 @@ import UserDropdown from './UserDropdown';
 import PatientInfoBlock from './PatientInfoBlock';
 import ConfirmationModal from './ConfirmationModal';
 import AddressSelector from './AddressSelector';
+import generateUUID from '../utils/generateUUID';
 
 // Register Spanish locale
 registerLocale('es', es);
@@ -85,7 +86,7 @@ const BulkServiceRequestView: React.FC<BulkServiceRequestViewProps> = ({
   // Initialize with 10 empty service slots
   useEffect(() => {
     const initialServices = Array.from({ length: 10 }, (_, index) => ({
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       origen: '',
       destino: '',
       ciudadOrigen: '',
@@ -158,7 +159,7 @@ const BulkServiceRequestView: React.FC<BulkServiceRequestViewProps> = ({
 
   const addMoreServices = () => {
     const newServices = Array.from({ length: 10 }, () => ({
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       origen: commonParams.origen,
       destino: commonParams.destino,
       ciudadOrigen: commonParams.ciudadOrigen,

--- a/src/components/CreateServiceModal.tsx
+++ b/src/components/CreateServiceModal.tsx
@@ -7,6 +7,7 @@ import { addDays, setHours, setMinutes, startOfDay } from 'date-fns';
 import { ServiceFormData, Authorization } from '../types';
 import AddressSelector from './AddressSelector';
 import { UserInfo } from '../types';
+import generateUUID from '../utils/generateUUID';
 
 interface CreateServiceModalProps {
   isOpen: boolean;
@@ -92,7 +93,7 @@ const CreateServiceModal: React.FC<CreateServiceModalProps> = ({
   const [selectedAuthorization, setSelectedAuthorization] = useState<Authorization | null>(null);
   
   const [service, setService] = useState<ServiceFormData>({
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     origen: '',
     destino: '',
     ciudadOrigen: '',
@@ -197,7 +198,7 @@ const CreateServiceModal: React.FC<CreateServiceModalProps> = ({
     setSearchError('');
     setIsConfirmed(false);
     setService({
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       origen: '',
       destino: '',
       ciudadOrigen: '',

--- a/src/components/SolicitudTransporteView.tsx
+++ b/src/components/SolicitudTransporteView.tsx
@@ -11,6 +11,7 @@ import ConfirmationModal from './ConfirmationModal';
 import AddressSelector from './AddressSelector';
 import LimitModal from './LimitModal';
 import CancelRequestModal from './CancelRequestModal';
+import generateUUID from '../utils/generateUUID';
 
 // Register Spanish locale
 registerLocale('es', es);
@@ -41,7 +42,7 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
     ? (authorization as any).volantes
     : [authorization.volante];
   const [services, setServices] = useState<ServiceFormData[]>([{
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     origen: '',
     destino: '',
     ciudadOrigen: '',
@@ -109,7 +110,7 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
   };
 
   const createReturnServiceFrom = (service: ServiceFormData): ServiceFormData => ({
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     origen: service.destino || '',
     destino: service.origen || '',
     ciudadOrigen: service.ciudadDestino || '',
@@ -162,7 +163,7 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
   };
 
   const createBulkService = (template?: ServiceFormData, tipo: 'IDA' | 'REGRESO' = 'IDA'): ServiceFormData => ({
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     origen: template?.origen || '',
     destino: template?.destino || '',
     ciudadOrigen: template?.ciudadOrigen || '',
@@ -198,8 +199,8 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
   };
 
   useEffect(() => {
-    setServices([{
-      id: crypto.randomUUID(),
+    setServices([{ 
+      id: generateUUID(),
       origen: '',
       destino: '',
       ciudadOrigen: '',
@@ -430,7 +431,7 @@ const SolicitudTransporteView: React.FC<SolicitudTransporteViewProps> = ({
   const addBulkRows = () => {
     const newRows = buildInitialBulkServices().map(service => ({
       ...service,
-      id: crypto.randomUUID()
+      id: generateUUID()
     }));
     setBulkServices(prev => [...prev, ...newRows]);
   };

--- a/src/utils/generateUUID.ts
+++ b/src/utils/generateUUID.ts
@@ -1,0 +1,44 @@
+const getCrypto = () => {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+
+  return (globalThis as { crypto?: Crypto }).crypto;
+};
+
+const randomWithMath = () =>
+  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const random = Math.random() * 16 | 0;
+    const value = char === 'x' ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+
+export const generateUUID = (): string => {
+  const cryptoRef = getCrypto();
+
+  if (cryptoRef?.randomUUID) {
+    return cryptoRef.randomUUID();
+  }
+
+  if (cryptoRef?.getRandomValues) {
+    const array = new Uint8Array(16);
+    cryptoRef.getRandomValues(array);
+
+    array[6] = (array[6] & 0x0f) | 0x40;
+    array[8] = (array[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
+
+    return [
+      hex.substring(0, 8),
+      hex.substring(8, 12),
+      hex.substring(12, 16),
+      hex.substring(16, 20),
+      hex.substring(20)
+    ].join('-');
+  }
+
+  return randomWithMath();
+};
+
+export default generateUUID;


### PR DESCRIPTION
## Summary
- add a UUID helper that falls back to crypto.getRandomValues and Math.random when crypto.randomUUID is unavailable
- switch the transport request flows to use the helper instead of directly calling crypto.randomUUID

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c980bcdf508323af231d7d41e9de1d